### PR TITLE
Model for battery round-trip losses; enable configurable simulation precision

### DIFF
--- a/ChargePlan.Builder/AdvancedAlgorithmBuilder.cs
+++ b/ChargePlan.Builder/AdvancedAlgorithmBuilder.cs
@@ -25,7 +25,8 @@ public record AdvancedAlgorithmBuilder(IPlant PlantTemplate,
     PlantState InitialState,
     ShiftableDemand[] ShiftableDemands,
     DemandCompleted[] CompletedDemands,
-    DateTime? ExplicitStartDate) : AlgorithmBuilder(PlantTemplate,
+    DateTime? ExplicitStartDate,
+    AlgorithmPrecision AlgorithmPrecision) : AlgorithmBuilder(PlantTemplate,
         DemandProfile,
         GenerationProfile,
         ChargeProfile,
@@ -35,7 +36,8 @@ public record AdvancedAlgorithmBuilder(IPlant PlantTemplate,
         InitialState,
         ShiftableDemands,
         CompletedDemands,
-        ExplicitStartDate)
+        ExplicitStartDate,
+        AlgorithmPrecision)
 {
     public AdvancedAlgorithmBuilder AddChargeWindow(PowerAtAbsoluteTimes template, DateTime day) => this with { ChargeProfile = ChargeProfile.Add(template.AsChargeProfile(day.Date)) };
     public AdvancedAlgorithmBuilder AddDemand(PowerAtAbsoluteTimes template, DateTime day) => this with { DemandProfile = DemandProfile.Add(template.AsDemandProfile(day.Date)) };

--- a/ChargePlan.Builder/AlgorithmBuilder.cs
+++ b/ChargePlan.Builder/AlgorithmBuilder.cs
@@ -14,10 +14,11 @@ public record AlgorithmBuilder(IPlant PlantTemplate,
         PlantState InitialState,
         ShiftableDemand[] ShiftableDemands,
         DemandCompleted[] CompletedDemands,
-        DateTime? ExplicitStartDate)
+        DateTime? ExplicitStartDate,
+        AlgorithmPrecision AlgorithmPrecision)
 {
     public AlgorithmBuilder(IPlant plantTemplate, IInterpolationFactory interpolationFactory)
-        : this(plantTemplate, new(), new GenerationProfile(), new(), new(), new(), interpolationFactory, plantTemplate.State, new ShiftableDemand[] {}, new DemandCompleted[] {}, null) {}
+        : this(plantTemplate, new(), new GenerationProfile(), new(), new(), new(), interpolationFactory, plantTemplate.State, new ShiftableDemand[] {}, new DemandCompleted[] {}, null, AlgorithmPrecision.Default) {}
 
     /// <summary>
     /// Set how much energy is in the battery storage at the start of the period.
@@ -42,6 +43,9 @@ public record AlgorithmBuilder(IPlant PlantTemplate,
         => this with { GenerationProfile = new GenerationProfile() { Values = kwhFigures.Select(f => new GenerationValue(f.DateTime, f.Power)).ToList() } };
     public AlgorithmBuilder WithGeneration(IGenerationProfile generationProfile)
         => this with { GenerationProfile = generationProfile };
+
+    public AlgorithmBuilder WithPrecision(AlgorithmPrecision precision)
+        => this with { AlgorithmPrecision = precision };
 
     /// <summary>
     /// Add a demand which needs to be run at some point on any day, and the algorithm will determine the optimum day and time to run it.
@@ -70,5 +74,5 @@ public record AlgorithmBuilder(IPlant PlantTemplate,
     /// Any further builder instructions will be for the supplied days. Existing ones are preserved.
     /// </summary>
     public AlgorithmBuilderForPeriod ForEachDay(params DateTime[] days)
-        => new(PlantTemplate, DemandProfile, GenerationProfile, ChargeProfile, PricingProfile, ExportProfile, InterpolationFactory, InitialState, ShiftableDemands, CompletedDemands, ExplicitStartDate, days);
+        => new(PlantTemplate, DemandProfile, GenerationProfile, ChargeProfile, PricingProfile, ExportProfile, InterpolationFactory, InitialState, ShiftableDemands, CompletedDemands, ExplicitStartDate, AlgorithmPrecision, days);
 }

--- a/ChargePlan.Builder/AlgorithmBuilderForPeriod.cs
+++ b/ChargePlan.Builder/AlgorithmBuilderForPeriod.cs
@@ -15,6 +15,7 @@ public record AlgorithmBuilderForPeriod(IPlant PlantTemplate,
         ShiftableDemand[] ShiftableDemands,
         DemandCompleted[] CompletedDemands,
         DateTime? ExplicitStartDate,
+        AlgorithmPrecision AlgorithmPrecision,
         params DateTime[] Days)
 {
     public AlgorithmBuilderForPeriod AddChargeWindow(PowerAtAbsoluteTimes template) => AddForEachDay((builder, day) => builder with { ChargeProfile = builder.ChargeProfile.Add(template.AsChargeProfile(day.Date)) });
@@ -42,7 +43,7 @@ public record AlgorithmBuilderForPeriod(IPlant PlantTemplate,
     /// Any further builder instructions will be for the supplied days. Existing ones are preserved.
     /// </summary>
     public AlgorithmBuilderForPeriod ForEachDay(params DateTime[] days)
-        => new(PlantTemplate, DemandProfile, GenerationProfile, ChargeProfile, PricingProfile, ExportProfile, InterpolationFactory, InitialState, ShiftableDemands, CompletedDemands, ExplicitStartDate, days);
+        => new(PlantTemplate, DemandProfile, GenerationProfile, ChargeProfile, PricingProfile, ExportProfile, InterpolationFactory, InitialState, ShiftableDemands, CompletedDemands, ExplicitStartDate, AlgorithmPrecision, days);
 
     private AlgorithmBuilderForPeriod AddForEachDay(Func<AlgorithmBuilderForPeriod, DateTime, AlgorithmBuilderForPeriod> action)
     {
@@ -65,5 +66,6 @@ public record AlgorithmBuilderForPeriod(IPlant PlantTemplate,
         InitialState,
         ShiftableDemands,
         CompletedDemands.Select(f => f.DemandHash).ToHashSet(),
-        ExplicitStartDate);
+        ExplicitStartDate,
+        AlgorithmPrecision);
 }

--- a/ChargePlan.ConsoleApp/Program.cs
+++ b/ChargePlan.ConsoleApp/Program.cs
@@ -132,7 +132,7 @@ var generation = await new WeatherBuilder(45.0f, 0.0f, 54.528728f, -1.553050f)
 
 Console.WriteLine(generation.ToString());
 
-var algorithm = new AlgorithmBuilder(new Hy36(5.2f, 2.8f, 2.8f, 3.6f, 80, 5), new ChargePlan.Domain.Splines.InterpolationFactory())
+var algorithm = new AlgorithmBuilder(new PlantFactory().CreatePlant("Hy36"), new ChargePlan.Domain.Splines.InterpolationFactory())
     .WithInitialBatteryEnergy(0.3f)
     .WithExplicitStartDate(DateTime.Today)
     .WithGeneration(generation)

--- a/ChargePlan.Domain.Plant/Hy36.cs
+++ b/ChargePlan.Domain.Plant/Hy36.cs
@@ -115,10 +115,12 @@ public record Hy36(
     {
         if (isGridCharge) return (state, 0.0f, energy);
 
-        float shortfallDueToEnergyDeltaLimit = Math.Max(0, energy - energyDeltaLimit);
-        float shortfallDueToEmpty = -Math.Min(0, (state.BatteryEnergy - LowerBoundsKilowattHrs) - energy);
+        float energyIncludingLosses = energy * BatteryDischargingEfficiencyScalar;
 
-        float deltaforBattery = Math.Min(energy * BatteryDischargingEfficiencyScalar, energyDeltaLimit);
+        float shortfallDueToEnergyDeltaLimit = Math.Max(0, energy - energyDeltaLimit);
+        float shortfallDueToEmpty = -Math.Min(0, (state.BatteryEnergy - LowerBoundsKilowattHrs) - energyIncludingLosses);
+
+        float deltaforBattery = Math.Min(energyIncludingLosses, energyDeltaLimit);
 
         float newState = Math.Max(LowerBoundsKilowattHrs, state.BatteryEnergy - deltaforBattery);
 

--- a/ChargePlan.Domain.Plant/Hy36.cs
+++ b/ChargePlan.Domain.Plant/Hy36.cs
@@ -12,7 +12,7 @@ public record Hy36(
     private float UpperBoundsKilowattHrs => (float)DepthOfDischargePercent * CapacityKilowattHrs / 100.0f;
     private float LowerBoundsKilowattHrs => (float)ReservePercent * CapacityKilowattHrs / 100.0f;
     private float BatteryChargingEfficiencyScalar => 1.0f - (1.0f - BatteryRoundRoundTripEfficiencyScalar) / 2.0f;
-    private float BatteryDischargingEfficiencyScalar => BatteryRoundRoundTripEfficiencyScalar;
+    private float BatteryDischargingEfficiencyScalar => 1.0f + (1.0f - BatteryRoundRoundTripEfficiencyScalar) / 2.0f;
 
     public override float ChargeRateAtScalar(float atScalarValue) => Math.Max(0.0f, Math.Min(1.0f, MaxChargeKilowatts * atScalarValue));
 

--- a/ChargePlan.Domain.Plant/Hy36.cs
+++ b/ChargePlan.Domain.Plant/Hy36.cs
@@ -5,11 +5,14 @@ public record Hy36(
     float MaxChargeKilowatts,
     float MaxDischargeKilowatts,
     float MaxThroughputKilowatts,
+    float BatteryRoundRoundTripEfficiencyScalar,
     int DepthOfDischargePercent,
     int ReservePercent) : IPlant(new(0.0f, 0.0f, 0.0f, 0.0f), new(0.0f))
 {
     private float UpperBoundsKilowattHrs => (float)DepthOfDischargePercent * CapacityKilowattHrs / 100.0f;
     private float LowerBoundsKilowattHrs => (float)ReservePercent * CapacityKilowattHrs / 100.0f;
+    private float BatteryChargingEfficiencyScalar => 1.0f - (1.0f - BatteryRoundRoundTripEfficiencyScalar) / 2.0f;
+    private float BatteryDischargingEfficiencyScalar => BatteryRoundRoundTripEfficiencyScalar;
 
     public override float ChargeRateAtScalar(float atScalarValue) => Math.Max(0.0f, Math.Min(1.0f, MaxChargeKilowatts * atScalarValue));
 
@@ -60,18 +63,18 @@ public record Hy36(
         PlantState newState = State;
 
         // Solar first.
-        var afterSolar = AddTo(newState, solarEnergy, UpperBoundsKilowattHrs, remainingBatteryChargeThroughput);
+        var afterSolar = AddTo(newState, solarEnergy, remainingBatteryChargeThroughput);
         newState = afterSolar.NewState;
         remainingBatteryChargeThroughput -= afterSolar.Added;
 
         // Grid charge second.
-        var afterGrid = AddTo(newState, chargeEnergy, UpperBoundsKilowattHrs, remainingBatteryChargeThroughput);
+        var afterGrid = AddTo(newState, chargeEnergy, remainingBatteryChargeThroughput);
         newState = afterGrid.NewState;
         remainingBatteryChargeThroughput -= afterGrid.Added;
 
         // Finally, pull energy out of battery for demand.
         // NB if this is a period of grid charging, then no drawdown from battery can be used for the demand.
-        var afterDemand = PullFrom(newState, demandEnergy, LowerBoundsKilowattHrs, afterGrid.Added > 0.0f, period.Energy(MaxDischargeKilowatts));
+        var afterDemand = PullFrom(newState, demandEnergy, afterGrid.Added > 0.0f, period.Energy(MaxDischargeKilowatts));
         newState = afterDemand.NewState;
 
         return this with
@@ -88,18 +91,18 @@ public record Hy36(
     /// <summary>
     /// Add some energy into the battery observing capacity limits.
     /// </summary>
-    private static (PlantState NewState, float Added, float Unused) AddTo(PlantState state, float energy, float energyLimit, float energyDeltaLimit)
+    private (PlantState NewState, float Added, float Unused) AddTo(PlantState state, float energy, float energyDeltaLimit)
     {
         float unusedDueToEnergyDeltaLimit = Math.Max(0, energy - energyDeltaLimit); // More power than system can cope with
-        float unusedDueToEnergyLimit = Math.Max(0, (state.BatteryEnergy + energy) - energyLimit); // More energy than the battery can hold
+        float unusedDueToEnergyLimit = Math.Max(0, (state.BatteryEnergy + energy) - UpperBoundsKilowattHrs); // More energy than the battery can hold
 
-        float deltaForBattery = Math.Min(energy, energyDeltaLimit);
+        float deltaForBattery = Math.Min(energy * BatteryChargingEfficiencyScalar, energyDeltaLimit);
 
-        float newState = Math.Min(energyLimit, state.BatteryEnergy + deltaForBattery);
+        float newState = Math.Min(UpperBoundsKilowattHrs, state.BatteryEnergy + deltaForBattery);
 
         return (
             state with { BatteryEnergy = newState },
-            energy - (unusedDueToEnergyLimit + unusedDueToEnergyDeltaLimit),
+            deltaForBattery,
             unusedDueToEnergyLimit + unusedDueToEnergyDeltaLimit
             );
     }
@@ -108,20 +111,20 @@ public record Hy36(
     /// Pull some energy from the battery observing where it is empty.
     /// </summary>
     /// <param name="isGridCharge">If true, this will not take from battery and return as shortfall.</param>
-    private static (PlantState NewState, float Pulled, float Shortfall) PullFrom(PlantState state, float energy, float energyLowerLimit, bool isGridCharge, float energyDeltaLimit)
+    private (PlantState NewState, float Pulled, float Shortfall) PullFrom(PlantState state, float energy, bool isGridCharge, float energyDeltaLimit)
     {
         if (isGridCharge) return (state, 0.0f, energy);
 
         float shortfallDueToEnergyDeltaLimit = Math.Max(0, energy - energyDeltaLimit);
-        float shortfallDueToEmpty = -Math.Min(0, (state.BatteryEnergy - energyLowerLimit) - energy);
+        float shortfallDueToEmpty = -Math.Min(0, (state.BatteryEnergy - LowerBoundsKilowattHrs) - energy);
 
-        float deltaforBattery = Math.Min(energy, energyDeltaLimit);
+        float deltaforBattery = Math.Min(energy * BatteryDischargingEfficiencyScalar, energyDeltaLimit);
 
-        float newState = Math.Max(energyLowerLimit, state.BatteryEnergy - deltaforBattery);
+        float newState = Math.Max(LowerBoundsKilowattHrs, state.BatteryEnergy - deltaforBattery);
 
         return (
             state with { BatteryEnergy = newState },
-            energy - (shortfallDueToEmpty + shortfallDueToEnergyDeltaLimit),
+            deltaforBattery,
             shortfallDueToEmpty + shortfallDueToEnergyDeltaLimit
             );
     }

--- a/ChargePlan.Domain.Plant/PlantFactory.cs
+++ b/ChargePlan.Domain.Plant/PlantFactory.cs
@@ -6,7 +6,7 @@ public class PlantFactory : IPlantFactory
 {
     public IPlant CreatePlant(string plantType) => plantType switch
     {
-        "Hy36" => new Hy36(5.2f, 2.8f, 2.8f, 3.6f, 94, 17),
+        "Hy36" => new Hy36(5.2f, 2.8f, 2.8f, 3.6f, 0.9f, 94, 17),
         _ => throw new InvalidStateException($"{plantType} is not a recognised plant type")
     };
 }

--- a/ChargePlan.Domain.Solver/Algorithm.cs
+++ b/ChargePlan.Domain.Solver/Algorithm.cs
@@ -11,7 +11,8 @@ public record Algorithm(
     PlantState InitialState,
     IEnumerable<IShiftableDemandProfile> ShiftableDemands,
     HashSet<string> CompletedDemands,
-    DateTimeOffset? ExplicitStartDate)
+    DateTimeOffset? ExplicitStartDate,
+    AlgorithmPrecision AlgorithmPrecision)
 {
     /// <summary>
     /// Iterate differing charge energies to arrive at the optimal given the predicted generation and demand.
@@ -116,7 +117,7 @@ public record Algorithm(
     {
         var chargeRates = Enumerable
             .Range(0, 101) // Go between 0 and 100%
-            .Chunk(5) // ...in steps of n%
+            .Chunk(AlgorithmPrecision.IterateInPercents) // ...in steps of n%
             .Select(percent => PlantTemplate.ChargeRateAtScalar((float)percent.First() / 100.0f));
 
         var results = chargeRates.Select(chargeLimit => new Calculator(PlantTemplate).Calculate(
@@ -128,6 +129,7 @@ public record Algorithm(
                 ExportProfile,
                 interpolationFactory,
                 InitialState,
+                AlgorithmPrecision.TimeStep,
                 chargeLimit,
                 ExplicitStartDate
             ))

--- a/ChargePlan.Domain.Solver/AlgorithmPrecision.cs
+++ b/ChargePlan.Domain.Solver/AlgorithmPrecision.cs
@@ -1,0 +1,6 @@
+namespace ChargePlan.Domain.Solver;
+
+public record AlgorithmPrecision(TimeSpan TimeStep, int IterateInPercents)
+{
+    public static AlgorithmPrecision Default = new(TimeSpan.FromMinutes(5), 20);
+}

--- a/ChargePlan.Service.UnitTests/Demands.cs
+++ b/ChargePlan.Service.UnitTests/Demands.cs
@@ -33,7 +33,7 @@ public class Demands
 
         var result = algorithm.DecideStrategy();
 
-        Assert.Equal(1.0M * 24.0M - 1.0M * (decimal)Calculator.TimeStep.TotalHours, result.Evaluation.TotalCost, 2);
+        Assert.Equal(1.0M * 24.0M - 1.0M * (decimal)algorithm.AlgorithmPrecision.TimeStep.TotalHours, result.Evaluation.TotalCost, 2);
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public class Demands
 
         var result = algorithm.DecideStrategy();
 
-        Assert.Equal(0.5M * 24.0M - 0.5M * (decimal)Calculator.TimeStep.TotalHours, result.Evaluation.TotalCost, 1);
+        Assert.Equal(0.5M * 24.0M - 0.5M * (decimal)algorithm.AlgorithmPrecision.TimeStep.TotalHours, result.Evaluation.TotalCost, 1);
     }
 
     [Fact]
@@ -110,6 +110,6 @@ public class Demands
 
         var result = algorithm.DecideStrategy();
 
-        Assert.Equal(12.0M - 0.25M * (decimal)Calculator.TimeStep.TotalHours, result.Evaluation.TotalCost, 0);
+        Assert.Equal(12.0M - 0.25M * (decimal)algorithm.AlgorithmPrecision.TimeStep.TotalHours, result.Evaluation.TotalCost, 0);
     }
 }

--- a/ChargePlan.Service.UnitTests/Demands.cs
+++ b/ChargePlan.Service.UnitTests/Demands.cs
@@ -2,7 +2,7 @@ namespace ChargePlan.Service.UnitTests;
 
 public class Demands
 {
-    private static IPlant UnlimitedPlant() => new Hy36(1000.0f, 1000.0f, 1000.0f, 1000.0f, 100, 0);
+    private static IPlant UnlimitedPlant() => new Hy36(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1.0f, 100, 0);
     private static PowerAtAbsoluteTimes ConstantDemand(float kw) => new PowerAtAbsoluteTimes(
         Name: "Constant Demand",
         Values: new()

--- a/ChargePlan.Service.UnitTests/Efficiency.cs
+++ b/ChargePlan.Service.UnitTests/Efficiency.cs
@@ -27,14 +27,13 @@ public class Efficiency
 
     [Theory]
     [InlineData(100, 0.0f)]
-    [InlineData(90, 0.1f * 3.5f)]
-    [InlineData(50, 0.5f * 3.0f)]
+    [InlineData(90, 0.1f * 4.0f)]
+    [InlineData(50, 0.5f * 4.0f)]
     public void GridCharge_Discharge_ConsidersEfficiency(float efficiencyPc, float expectedCost)
     {
         var algorithm = new AlgorithmBuilder(UnlimitedPlant(efficiencyPc), Interpolations.Step())
-            .WithGeneration(DateTime.Today.AddDays(1), new float[] { 1.0f, 1.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f }) // 4hrs generate, 4hrs not
-            .WithInitialBatteryEnergy(0.0f)
             .WithPrecision(AlgorithmPrecision.Default with { TimeStep = TimeSpan.FromHours(1) })
+            .WithGeneration(DateTime.Today.AddDays(1), new float[] { 1.0f, 1.0f, 1.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f }) // 4hrs generate, 4hrs not
             .ForDay(DateTime.Today.AddDays(1))
             .AddPricing(ConstantPrice(1.0M))
             .AddDemand(new PowerAtAbsoluteTimes(
@@ -43,7 +42,8 @@ public class Efficiency
                 {
                     new (TimeOnly.MinValue, 0.0f), // 4hrs no demand, then 4hrs with demand.
                     new (new(04,00), 1.0f),
-                    new (new(08,00), 0.0f)
+                    new (new(08,00), 0.0f),
+                    new (new(09,00), 0.0f)
                 }
             ))
             .Build();

--- a/ChargePlan.Service.UnitTests/Efficiency.cs
+++ b/ChargePlan.Service.UnitTests/Efficiency.cs
@@ -1,0 +1,43 @@
+namespace ChargePlan.Service.UnitTests;
+
+public class Efficiency
+{
+    private static IPlant UnlimitedPlant(float efficiencyPc) => new Hy36(1000.0f, 1000.0f, 1000.0f, 1000.0f, efficiencyPc / 100.0f, 100, 0);
+
+    private static PowerAtAbsoluteTimes ConstantDemand(float kw) => new PowerAtAbsoluteTimes(
+        Name: "Constant Demand",
+        Values: new()
+        {
+            new (TimeOnly.MinValue, kw),
+            new (new(04,00), kw),
+            new (new(08,00), kw),
+            new (new(12,00), kw),
+            new (TimeOnly.MaxValue, kw)
+        }
+    );
+    private static PriceAtAbsoluteTimes ConstantPrice(decimal perHour) => new PriceAtAbsoluteTimes(
+        Name: $"{perHour} per hour",
+        Values: new()
+        {
+            new (TimeOnly.MinValue, perHour),
+        }
+    );
+
+    [Theory]
+//    [InlineData(100, 0.0f)]
+    [InlineData(90, 24 * 0.9f * 1.0f)]
+    public void GridCharge_Discharge_ConsidersEfficiency(float efficiencyPc, float expectedCost)
+    {
+        var algorithm = new AlgorithmBuilder(UnlimitedPlant(efficiencyPc), Interpolations.Step())
+            .WithGeneration(DateTime.Today.AddDays(1), new float[] { 1.0f })
+            .WithInitialBatteryEnergy(0.0f)
+            .ForDay(DateTime.Today.AddDays(1))
+            .AddPricing(ConstantPrice(1.0M))
+            .AddDemand(ConstantDemand(1.0f))
+            .Build();
+
+        var result = algorithm.DecideStrategy();
+
+        Assert.Equal(expectedCost, (float)result.Evaluation.TotalCost, 2);
+    }
+}

--- a/ChargePlan.Service.UnitTests/Overcharge.cs
+++ b/ChargePlan.Service.UnitTests/Overcharge.cs
@@ -2,9 +2,9 @@ namespace ChargePlan.Service.UnitTests;
 
 public class Overcharge
 {
-    private static IPlant LimitedThroughputPlant(float throughput) => new Hy36(1000.0f, 1000.0f, 1000.0f, throughput, 100, 0);
-    private static IPlant LimitedCapacityBattery(float capacity) => new Hy36(capacity, 1000.0f, 1000.0f, 1000.0f, 100, 0);
-    private static IPlant LimitedDischargeBattery(float throughput) => new Hy36(1000.0f, 1000.0f, throughput, 1000.0f, 100, 0);
+    private static IPlant LimitedThroughputPlant(float throughput) => new Hy36(1000.0f, 1000.0f, 1000.0f, throughput, 1.0f, 100, 0);
+    private static IPlant LimitedCapacityBattery(float capacity) => new Hy36(capacity, 1000.0f, 1000.0f, 1000.0f, 1.0f, 100, 0);
+    private static IPlant LimitedDischargeBattery(float throughput) => new Hy36(1000.0f, 1000.0f, throughput, 1000.0f, 1.0f, 100, 0);
     private static PowerAtAbsoluteTimes ConstantDemand(float kw) => new PowerAtAbsoluteTimes(
         Name: "Constant Demand",
         Values: new()

--- a/ChargePlan.Service.UnitTests/Plant.cs
+++ b/ChargePlan.Service.UnitTests/Plant.cs
@@ -2,9 +2,9 @@ namespace ChargePlan.Service.UnitTests;
 
 public class Plant
 {
-    private static IPlant LimitedThroughputPlant(float throughput) => new Hy36(1000.0f, 1000.0f, 1000.0f, throughput, 100, 0);
-    private static IPlant LimitedCapacityBattery(float capacity) => new Hy36(capacity, 1000.0f, 1000.0f, 1000.0f, 100, 0);
-    private static IPlant LimitedDischargeBattery(float throughput) => new Hy36(1000.0f, 1000.0f, throughput, 1000.0f, 100, 0);
+    private static IPlant LimitedThroughputPlant(float throughput, float chargingEfficiency = 1.0f) => new Hy36(1000.0f, 1000.0f, 1000.0f, throughput, chargingEfficiency, 100, 0);
+    private static IPlant LimitedCapacityBattery(float capacity, float chargingEfficiency = 1.0f) => new Hy36(capacity, 1000.0f, 1000.0f, 1000.0f, chargingEfficiency, 100, 0);
+    private static IPlant LimitedDischargeBattery(float throughput, float chargingEfficiency = 1.0f) => new Hy36(1000.0f, 1000.0f, throughput, 1000.0f, chargingEfficiency, 100, 0);
     private static PowerAtAbsoluteTimes ConstantDemand(float kw) => new PowerAtAbsoluteTimes(
         Name: "Constant Demand",
         Values: new()

--- a/ChargePlan.Service.UnitTests/Plant.cs
+++ b/ChargePlan.Service.UnitTests/Plant.cs
@@ -40,7 +40,7 @@ public class Plant
 
         var result = algorithm.DecideStrategy();
 
-        Assert.Equal(0.5M * 24.0M - 0.5M * (decimal)Calculator.TimeStep.TotalHours, result.Evaluation.TotalCost, 1);
+        Assert.Equal(0.5M * 24.0M - 0.5M * (decimal)algorithm.AlgorithmPrecision.TimeStep.TotalHours, result.Evaluation.TotalCost, 1);
     }
 
     [Fact]
@@ -55,7 +55,7 @@ public class Plant
 
         var result = algorithm.DecideStrategy();
 
-        Assert.Equal(0.5M * 24.0M - 0.5M * (decimal)Calculator.TimeStep.TotalHours, result.Evaluation.TotalCost, 1);
+        Assert.Equal(0.5M * 24.0M - 0.5M * (decimal)algorithm.AlgorithmPrecision.TimeStep.TotalHours, result.Evaluation.TotalCost, 1);
     }
 
     [Fact]
@@ -71,6 +71,6 @@ public class Plant
 
         var result = algorithm.DecideStrategy();
 
-        Assert.Equal(0.5M * 12.0M - 1.0M * (decimal)Calculator.TimeStep.TotalHours, result.Evaluation.TotalCost, 2);
+        Assert.Equal(0.5M * 12.0M - 1.0M * (decimal)algorithm.AlgorithmPrecision.TimeStep.TotalHours, result.Evaluation.TotalCost, 2);
     }
 }

--- a/ChargePlan.Service.UnitTests/Timezones.cs
+++ b/ChargePlan.Service.UnitTests/Timezones.cs
@@ -4,7 +4,7 @@ namespace ChargePlan.Service.UnitTests;
 
 public class Timezones
 {
-    private static IPlant UnlimitedPlant() => new Hy36(1000.0f, 1000.0f, 1000.0f, 1000.0f, 100, 0);
+    private static IPlant UnlimitedPlant() => new Hy36(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1.0f, 100, 0);
     private static PowerAtAbsoluteTimes ZeroDemand() => new PowerAtAbsoluteTimes(
         Name: "Zero Demand",
         Values: new()

--- a/ChargePlan.Service.UnitTests/UnitTest1.cs
+++ b/ChargePlan.Service.UnitTests/UnitTest1.cs
@@ -5,7 +5,7 @@ namespace ChargePlan.Service.UnitTests;
 
 public class UnitTest1
 {
-    private static IPlant Plant() => new Hy36(5.2f, 2.8f, 2.8f, 3.6f, 80, 5);
+    private static IPlant Plant() => new Hy36(5.2f, 2.8f, 2.8f, 3.6f, 1.0f, 80, 5);
 
     [Theory]
     [InlineData(0, Math.PI / 2, 0, Math.PI / 2)]
@@ -59,7 +59,7 @@ public class UnitTest1
             }
         );
 
-        var hugeBattery = new Hy36(1000.0f, 1000.0f, 1000.0f, 1000.0f, 100, 0);
+        var hugeBattery = new Hy36(1000.0f, 1000.0f, 1000.0f, 1000.0f, 1.0f, 100, 0);
 
         var algorithm = new AlgorithmBuilder(hugeBattery, Interpolations.Step())
             .WithInitialBatteryEnergy(1000.0f)

--- a/ChargePlan.Weather.OpenMeteo/DniProvider.cs
+++ b/ChargePlan.Weather.OpenMeteo/DniProvider.cs
@@ -21,11 +21,10 @@ public class DniProvider : IDirectNormalIrradianceProvider
 
         var entity = await JsonSerializer.DeserializeAsync<ResponseEntity>(response.Content.ReadAsStream()) ?? throw new InvalidOperationException();
 
-        // Note the OpenMeteo forecast is for the "preceding hour"
         var values = entity.hourly.time
             .Zip(entity.hourly.direct_normal_irradiance, entity.hourly.diffuse_radiation, entity.hourly.cloudcover)
             .Select(items => new DniValue(
-                DateTime: DateTime.Parse(items.First + ":00.000Z"),
+                DateTime: DateTime.Parse(items.First + ":00.000Z").AddHours(-1), // Note the OpenMeteo forecast is for the "preceding hour"
                 DirectWatts: (float)items.Second,
                 DiffuseWatts: (float?)items.Third,
                 CloudCoverPercent: items.Fourth)

--- a/ChargePlan.Weather/IDirectNormalIrradianceProvider.cs
+++ b/ChargePlan.Weather/IDirectNormalIrradianceProvider.cs
@@ -13,7 +13,7 @@ public interface IDirectNormalIrradianceProvider
 /// <param name="DiffuseWatts">Watts of sunlight from diffuse sky (i.e. shaded surface). Null if unknown.</param>
 /// <param name="CloudCoverPercent">Cloud cover percentage at the time of the estimate. Null if unknown.</param>
 public record DniValue(
-    DateTime DateTime,
+    DateTimeOffset DateTime,
     float DirectWatts,
     float? DiffuseWatts,
     int? CloudCoverPercent

--- a/ChargePlan.Weather/Sol.cs
+++ b/ChargePlan.Weather/Sol.cs
@@ -18,7 +18,7 @@ public static class Sol
         return Math.Max(diffuseIrradiation ?? 0.0, dni * Math.Max(0.0f, Math.Cos(azimuth)) * Math.Max(0.0f, Math.Sin(Math.Abs(elevation))));
     }
 
-    public static (double Altitude, double Azimuth) SunPositionRads(DateTime dateTime, float latitudeDegrees, float longitudeDegrees)
+    public static (double Altitude, double Azimuth) SunPositionRads(DateTimeOffset dateTime, float latitudeDegrees, float longitudeDegrees)
     {
         // double latRadians = latitudeDegrees * Math.PI / 180.0;
         // double declination = DeclinationRads(dateTime);
@@ -31,7 +31,7 @@ public static class Sol
         // azimuth = 360 * azimuth / (2.0 * Math.PI);;
 
         // return (altitude, azimuth);
-        var result = SunCalcSharp.SunCalc.GetPosition(dateTime, latitudeDegrees, longitudeDegrees);
+        var result = SunCalcSharp.SunCalc.GetPosition(dateTime.UtcDateTime, latitudeDegrees, longitudeDegrees);
 
         return (result.Altitude, result.Azimuth);
     }

--- a/ChargePlan.Weather/WeatherBuilder.cs
+++ b/ChargePlan.Weather/WeatherBuilder.cs
@@ -54,7 +54,7 @@ public record WeatherBuilder(IDirectNormalIrradianceProvider? DniProvider, float
                 float kw = IrradianceToPowerScalar * (float)irradiatedPower / 1000.0f;
                 kw = Math.Min(kw, (AbsolutePeakWatts ?? int.MaxValue) / 1000.0f);
 
-                return new GenerationValue(f.DateTime.ToLocalTime(), kw);
+                return new GenerationValue(f.DateTime.LocalDateTime, kw);
             });
         }
         else


### PR DESCRIPTION
* Support for round-trip efficiency losses, including Unit Tests. Defaults set to 90% for Hy3.6
* Simulation precision is now configurable in the Builder: both for integration precision (simulation timestep) and for charge level trials (number of iterations)