### PR TITLE
Fix for timezone changes

### DIFF
--- a/ChargePlan.Domain.Plant/Hy36.cs
+++ b/ChargePlan.Domain.Plant/Hy36.cs
@@ -20,6 +20,11 @@ public record Hy36(
     {
         float wasted = 0.0f;
 
+        if (float.IsFinite(solarEnergy) == false) throw new ArgumentOutOfRangeException(nameof(solarEnergy), solarEnergy, "Must be finite");
+        if (float.IsFinite(chargeEnergy) == false) throw new ArgumentOutOfRangeException(nameof(chargeEnergy), chargeEnergy, "Must be finite");
+        if (float.IsFinite(demandEnergy) == false) throw new ArgumentOutOfRangeException(nameof(demandEnergy), demandEnergy, "Must be finite");
+        if (period <= TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), period, "Must be positive");
+
         // ----
         // Set some limits for energy being processed.
 

--- a/ChargePlan.Domain/Calculator.cs
+++ b/ChargePlan.Domain/Calculator.cs
@@ -75,8 +75,6 @@ public record Calculator(IPlant PlantTemplate)
             float generationEnergy = Math.Max(0.0f, (float)generationSpline.Integrate(from, to));
             float chargeEnergy = (float)Math.Max(0.0f, Math.Min(chargeSpline.Integrate(from, to), step.Energy(chargePowerLimit ?? float.MaxValue)));
 
-            if (float.IsFinite(generationEnergy) == false) generationEnergy = 0.0f;
-
             plant = plant.IntegratedBy(generationEnergy, chargeEnergy, demandEnergy, step);
             
             plant.ThrowIfInvalid();

--- a/ChargePlan.Domain/Exceptions/InvalidStateException.cs
+++ b/ChargePlan.Domain/Exceptions/InvalidStateException.cs
@@ -5,4 +5,6 @@ public class InvalidStateException : Exception
     public InvalidStateException() { }
 
     public InvalidStateException(string message) : base(message) { }
+
+    public InvalidStateException(string message, Exception innerException) : base(message, innerException) { }
 }

--- a/ChargePlan.Domain/IGenerationProfile.cs
+++ b/ChargePlan.Domain/IGenerationProfile.cs
@@ -4,4 +4,4 @@ public interface IGenerationProfile : ISplineable<GenerationValue>
 {
 }
 
-public record GenerationValue(DateTime DateTime, float Power);
+public record GenerationValue(DateTimeOffset DateTime, float Power);

--- a/ChargePlan.Domain/IPlant.cs
+++ b/ChargePlan.Domain/IPlant.cs
@@ -1,3 +1,5 @@
+using ChargePlan.Domain.Exceptions;
+
 namespace ChargePlan.Domain;
 
 public abstract record IPlant(PlantIntegration LastIntegration, PlantState State)
@@ -22,6 +24,14 @@ public abstract record IPlant(PlantIntegration LastIntegration, PlantState State
     /// </summary>
     public float? ChargeRateWithSafetyFactor(float? chargeRate, float safetyScalarValue)
         => chargeRate == null ? null : Math.Max(chargeRate.Value * safetyScalarValue, ChargeRateAtScalar(1.0f));
+
+    public void ThrowIfInvalid()
+    {
+        if (float.IsNaN(LastIntegration.GridCharged) || float.IsFinite(LastIntegration.GridCharged) == false) throw new InvalidStateException($"Invalid LastIntegration.GridCharged: {LastIntegration}");
+        if (float.IsNaN(LastIntegration.GridExport) || float.IsFinite(LastIntegration.GridExport) == false) throw new InvalidStateException($"Invalid LastIntegration.GridExport: {LastIntegration}");
+        if (float.IsNaN(LastIntegration.Shortfall) || float.IsFinite(LastIntegration.Shortfall) == false) throw new InvalidStateException($"Invalid LastIntegration.Shortfall: {LastIntegration}");
+        if (float.IsNaN(LastIntegration.Wasted) || float.IsFinite(LastIntegration.Wasted) == false) throw new InvalidStateException($"Invalid LastIntegration.Wasted: {LastIntegration}");
+    }
 }
 
 public record PlantIntegration(float GridCharged, float GridExport, float Shortfall, float Wasted);

--- a/ChargePlan.Domain/TimeExtensions.cs
+++ b/ChargePlan.Domain/TimeExtensions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.Design;
+using ChargePlan.Domain.Exceptions;
 
 namespace ChargePlan.Domain;
 
@@ -12,7 +13,11 @@ public static class TimeExtensions
     /// <summary>
     /// Calculate average power to have produced this amount of energy over this duration.
     /// </summary>
-    public static float Power(this TimeSpan ts, float Energy) => Energy / (float)ts.TotalHours;
+    public static float Power(this TimeSpan ts, float Energy)
+    {
+        if (ts == TimeSpan.Zero) throw new InvalidStateException($"Cannot convert energy {Energy} to power over zero measure of time");
+        return Energy / (float)ts.TotalHours;
+    }
 
     /// <summary>
     /// Represent a datetime as a fractional number of hours since mindate.

--- a/ChargePlan.Domain/TimeExtensions.cs
+++ b/ChargePlan.Domain/TimeExtensions.cs
@@ -27,7 +27,7 @@ public static class TimeExtensions
     /// <summary>
     /// Represent a datetime as a fractional number of hours since mindate.
     /// </summary>
-    public static double AsTotalHours(this DateTimeOffset dateTime) => (double)dateTime.Ticks / (double)TimeSpan.FromHours(1.0).Ticks;
+    public static double AsTotalHours(this DateTimeOffset dateTime) => (double)dateTime.UtcTicks / (double)TimeSpan.FromHours(1.0).Ticks;
 
     /// <summary>
     /// Align to the closest previous hour

--- a/ChargePlan.Weather.OpenMeteo/DniProvider.cs
+++ b/ChargePlan.Weather.OpenMeteo/DniProvider.cs
@@ -24,7 +24,7 @@ public class DniProvider : IDirectNormalIrradianceProvider
         var values = entity.hourly.time
             .Zip(entity.hourly.direct_normal_irradiance, entity.hourly.diffuse_radiation, entity.hourly.cloudcover)
             .Select(items => new DniValue(
-                DateTime: DateTime.Parse(items.First + ":00.000Z").AddHours(-1), // Note the OpenMeteo forecast is for the "preceding hour"
+                DateTime: DateTime.ParseExact(items.First + ":00.000", "yyyy-MM-ddTHH:mm:ss.fff", null, System.Globalization.DateTimeStyles.AssumeLocal).AddHours(-1), // Note the OpenMeteo forecast is for the "preceding hour"
                 DirectWatts: (float)items.Second,
                 DiffuseWatts: (float?)items.Third,
                 CloudCoverPercent: items.Fourth)

--- a/ChargePlan.Weather/Shading.cs
+++ b/ChargePlan.Weather/Shading.cs
@@ -36,6 +36,8 @@ public record Shading(IEnumerable<(float Altitude, float Azimuth)> Points)
             startX = endX; startY = endY;
             endPoint = polygon[i++];
             endX = endPoint.Azimuth; endY = endPoint.Altitude;
+
+            //if ((startY - endY) == 0.0f) throw new InvalidOperationException($"Cannot calculate Sun position shading because start and end points are the same. {String.Join(" ", Points.Select(f=>$"({f.Altitude},{f.Azimuth})"))}");
             //
             inside ^= (endY > pointY ^ startY > pointY) /* ? pointY inside [startY;endY] segment ? */
             && /* if so, test if it is under the segment */

--- a/ChargePlan.Weather/WeatherBuilder.cs
+++ b/ChargePlan.Weather/WeatherBuilder.cs
@@ -54,7 +54,7 @@ public record WeatherBuilder(IDirectNormalIrradianceProvider? DniProvider, float
                 float kw = IrradianceToPowerScalar * (float)irradiatedPower / 1000.0f;
                 kw = Math.Min(kw, (AbsolutePeakWatts ?? int.MaxValue) / 1000.0f);
 
-                return new GenerationValue(f.DateTime.LocalDateTime, kw);
+                return new GenerationValue(f.DateTime, kw);
             });
         }
         else


### PR DESCRIPTION
OpenMeteo weather forecast code was mistakenly treating the API as UTC rather than Local time, causing ultimately a NaN calculation in the solar generation spline.

Added a load of bounds checking in the course of fixing the problem.